### PR TITLE
Updating the SvelteKit config file to comply with the new changes to Sveltekit SSR

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,8 +6,15 @@ const config = {
 	kit: {
 		adapter: adapter({}),
 		target: '#svelte',
-		ssr: false,
 	},
 	preprocess: sveltePreprocess(),
 };
 export default config;
+
+/* Disabling Sveltekit SSR has to be done in the handle function now */
+export async function handle({ request, resolve }) {
+    const response = await resolve(request, {
+        ssr: false
+    });
+    return response;
+}


### PR DESCRIPTION
## Changes
SvelteKit[ made some changes](https://github.com/sveltejs/kit/blob/master/packages/kit/CHANGELOG.md#100-next222) to how you disable SSR. Without the changes you get the following error. This should solve issue #15 
``` bash
[svelte] > config.kit.ssr has been removed — use the handle hook instead: https://kit.svelte.dev/docs#hooks-handle
[svelte]     at file:///Users/x/Documents/p/sveltekit-electron/node_modules/@sveltejs/kit/dist/cli.js:650:12
[svelte]     at file:///Users/x/Documents/p/sveltekit-electron/node_modules/@sveltejs/kit/dist/cli.js:729:43
[svelte]     at file:///Users/x/Documents/p/sveltekit-electron/node_modules/@sveltejs/kit/dist/cli.js:715:18
[svelte]     at file:///Users/x/Documents/p/sveltekit-electron/node_modules/@sveltejs/kit/dist/cli.js:715:18
[svelte]     at validate_config (file:///Users/x/Documents/p/sveltekit-electron/node_modules/@sveltejs/kit/dist/cli.js:874:9)
[svelte]     at load_config (file:///Users/x/Documents/p/sveltekit-electron/node_modules/@sveltejs/kit/dist/cli.js:851:20)
[svelte]     at async file:///Users/x/Documents/p/sveltekit-electron/node_modules/@sveltejs/kit/dist/cli.js:948:19
[svelte] npm run dev:svelte exited with code 1
```

If you don't have these changes you get stuck in an infinite loop of
``` bash
[electron] Error loading URL, retrying Error: ERR_CONNECTION_REFUSED (-102) loading 'http://localhost:3000/'
[electron]     at rejectAndCleanup (electron/js2c/browser_init.js:217:1457)
[electron]     at Object.failListener (electron/js2c/browser_init.js:217:1670)
[electron]     at Object.emit (events.js:315:20) {
[electron]   errno: -102,
[electron]   code: 'ERR_CONNECTION_REFUSED',
[electron]   url: 'http://localhost:3000/'
[electron] }
```

## Does everything work the same
Yep, with no other changes it starts up fine
![image](https://user-images.githubusercontent.com/21166352/150656675-8e8e5f80-5788-4b47-b39b-52545f2ff3e9.png)
