### PR TITLE
Update svelte.config.js Fixes#18

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,6 @@ import adapter from '@sveltejs/adapter-static';
 const config = {
 	kit: {
 		adapter: adapter({}),
-		target: '#svelte',
 	},
 	preprocess: sveltePreprocess(),
 };


### PR DESCRIPTION
Fixes #18

config.kit.target is no longer required, and should be removed