### PR TITLE
Update adapter setting in svelte.config.js

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,7 +4,7 @@ import adapter from '@sveltejs/adapter-static';
 /** @type {import("@sveltejs/kit").Config} */
 const config = {
 	kit: {
-		adapter: adapter({}),
+		adapter: adapter({fallback:true}),
 	},
 	preprocess: sveltePreprocess(),
 };


### PR DESCRIPTION
fallback option by default is null.  When executing build, "npm run build," fallback is needed.